### PR TITLE
Update M365lpConfiguration.ps1

### DIFF
--- a/webpart/M365lpConfiguration.ps1
+++ b/webpart/M365lpConfiguration.ps1
@@ -85,6 +85,16 @@ if ($AppCatalogAdmin) {
 
   }
   $appcatalog = Get-PnPTenantAppCatalogUrl
+
+  # Explicitly connect to the App Catalog site collection to avoid a potential 403 on Set-PnPStorageEntity
+  try {
+    Connect-PnPOnline -Url $appcatalog -Credentials $Credentials
+  }
+  catch {
+    Write-Host "Failed to authenticate to $appcatalog"
+    Write-Host $_
+    break
+  }
     
   try {
     # Test that user can write values to the App Catalog


### PR DESCRIPTION
In some scenarios, users will receive a 403 error when attempting to call Set-PnPStorageEntity. Explicitly connecting to the App Catalog before Set-PnPStorageEntity ensures the connection to avoid the 403.