### PR TITLE
Corrent German-Translation for Product "Access"

### DIFF
--- a/docs/learningpathways/v4/de-de/metadata.json
+++ b/docs/learningpathways/v4/de-de/metadata.json
@@ -325,7 +325,7 @@
         },
         {
           "Id": "175c2d96-040d-4275-9405-b4549bd63dee",
-          "Name": "Zugriff",
+          "Name": "Access",
           "Image": "images/categories/access.png",
           "TechnologyId": "",
           "SubjectId": null,


### PR DESCRIPTION
In Germany we don't translate the Office-Product Name Access to "Zugriff" we called it the same as the Original - we call it "Access"