### PR TITLE
Validate if tenant app catalog Custom scripts is blocked

### DIFF
--- a/installation/TelemetryOptOut.ps1
+++ b/installation/TelemetryOptOut.ps1
@@ -32,8 +32,28 @@ catch {
   Write-Warning $_
   break
 }
+
+# Validate if tenant app catalog Custom scripts is blocked
+try {
+  $appcatalog = Get-PnPTenantAppCatalogUrl
+
+  $noScript = $false
+  $siteInfo = Get-PnPTenantSite -Url $appcatalog
+  if ($siteInfo.DenyAddAndCustomizePages -ne "Disabled") { 
+    # Enable custom scripts on the tenant app catalog (allowed)
+    Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$false
+    $noScript = $true
+  }
+} catch { }
     
 Set-PnPStorageEntity -Key MicrosoftCustomLearningTelemetryOn -Value $false -Description "Microsoft 365 learning pathways Telemetry Setting"
 Get-PnPStorageEntity -Key MicrosoftCustomLearningTelemetryOn
+
+# Revert to original setting (blocked)
+try {
+  if($noScript -eq $true) {
+    Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$true
+  }
+} catch { }
 
 Disconnect-PnPOnline

--- a/installation/UpdateM365lpCDN.ps1
+++ b/installation/UpdateM365lpCDN.ps1
@@ -47,7 +47,27 @@ catch {
   break
 }
 
+# Validate if tenant app catalog Custom scripts is blocked
+try {
+  $appcatalog = Get-PnPTenantAppCatalogUrl
+
+  $noScript = $false
+  $siteInfo = Get-PnPTenantSite -Url $appcatalog
+  if ($siteInfo.DenyAddAndCustomizePages -ne "Disabled") { 
+    # Enable custom scripts on the tenant app catalog (allowed)
+    Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$false
+    $noScript = $true
+  }
+} catch { }
+
 Set-PnPStorageEntity -Key MicrosoftCustomLearningCdn -Value "https://pnp.github.io/custom-learning-office-365/learningpathways/" -Description "Microsoft 365 learning pathways CDN source" -ErrorAction Stop
 Get-PnPStorageEntity -Key MicrosoftCustomLearningCdn
+
+# Revert to original setting (blocked)
+try {
+  if($noScript -eq $true) {
+    Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$true
+  }
+} catch { }
 
 Disconnect-PnPOnline

--- a/installation/UpdateM365lpSiteUrl.ps1
+++ b/installation/UpdateM365lpSiteUrl.ps1
@@ -45,7 +45,27 @@ catch {
   break
 }
 
+# Validate if tenant app catalog Custom scripts is blocked
+try {
+  $appcatalog = Get-PnPTenantAppCatalogUrl
+
+  $noScript = $false
+  $siteInfo = Get-PnPTenantSite -Url $appcatalog
+  if ($siteInfo.DenyAddAndCustomizePages -ne "Disabled") { 
+    # Enable custom scripts on the tenant app catalog (allowed)
+    Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$false
+    $noScript = $true
+  }
+} catch { }
+
 Set-PnPStorageEntity -Key MicrosoftCustomLearningSite -Value $M365LPSiteUrl -Description "Microsoft 365 learning pathways Site Collection"
 Get-PnPStorageEntity -Key MicrosoftCustomLearningSite
+
+# Revert to original setting (blocked)
+try {
+  if($noScript -eq $true) {
+    Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$true
+  }
+} catch { }
 
 Disconnect-PnPOnline

--- a/src/DeveloperSetup.ps1
+++ b/src/DeveloperSetup.ps1
@@ -2,12 +2,33 @@ $clSite = "https://contoso.sharepoint.com/sites/M365LP"
 
 try {
   Connect-PnPOnline -Url $clSite -UseWebLogin
+
+  # Validate if tenant app catalog Custom scripts is blocked
+  try {
+    $appcatalog = Get-PnPTenantAppCatalogUrl
+
+    $noScript = $false
+    $siteInfo = Get-PnPTenantSite -Url $appcatalog
+    if ($siteInfo.DenyAddAndCustomizePages -ne "Disabled") { 
+      # Enable custom scripts on the tenant app catalog (allowed)
+      Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$false
+      $noScript = $true
+    }
+  } catch { }
+
   Set-PnPStorageEntity -Key MicrosoftCustomLearningCdn -Value "https://pnp.github.io/custom-learning-office-365/learningpathways/" -Description "CDN source for Microsoft 365 learning pathways Content"
   Get-PnPStorageEntity -Key MicrosoftCustomLearningCdn
   Set-PnPStorageEntity -Key MicrosoftCustomLearningSite -Value $clSite -Description "M365 learning pathways Site Collection"
   Get-PnPStorageEntity -Key MicrosoftCustomLearningSite
   Set-PnPStorageEntity -Key MicrosoftCustomLearningTelemetryOn -Value $true -Description "M365 learning pathways Telemetry Collection"
   Get-PnPStorageEntity -Key MicrosoftCustomLearningTelemetryOn
+
+  # Revert to original setting (blocked)
+  try {
+    if($noScript -eq $true) {
+      Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$true
+    }
+  } catch { }
 
   $clv = Get-PnPListItem -List "Site Pages" -Query "<View><Query><Where><Eq><FieldRef Name='FileLeafRef'/><Value Type='Text'>CustomLearningViewer.aspx</Value></Eq></Where></Query></View>"
   if ($clv -eq $null) {
@@ -37,5 +58,12 @@ try {
 catch {
   Write-Error "Failed to authenticate to $siteUrl"
   Write-Error $_.Exception
+
+  # Revert to original setting (blocked)
+  try {
+    if($noScript -eq $true) {
+      Set-PnPTenantSite -Identity $appcatalog -DenyAddAndCustomizePages:$true
+    }
+  } catch { }
 }
 


### PR DESCRIPTION
Ensure Custom Scripts is allowed on the App Catalog Site before update StorageEntity
This relates to #979 - Set-PnPStorageEntity Access Denied when running configuring Powershell script