### PR TITLE
Fix Site Pages lookup on non-English sites (#1013)

### DIFF
--- a/installation/M365lpConfiguration.ps1
+++ b/installation/M365lpConfiguration.ps1
@@ -175,7 +175,10 @@ if ($SiteAdmin) {
     Write-Warning "Could not find `"Microsoft 365 learning pathways`" app. Please install in it your app catalog and run this script again."
     break
   }
-  $sitePagesList = Get-PnPList -Identity "Site Pages"
+  # Resolve by stable EntityTypeName instead of the localized Title, since SharePoint
+  # renames the built-in "Site Pages" library according to the site's default language
+  # (e.g. "Páginas del sitio" on es-ES sites) - see issue #1013
+  $sitePagesList = Get-PnPList | Where-Object { $_.EntityTypeName -eq "SitePages" }
   if ($null -ne $sitePagesList) {    
     # Delete pages if they exist. Alert user.
     $clv = Get-PnPListItem -List $sitePagesList -Query "<View><Query><Where><Eq><FieldRef Name='FileLeafRef'/><Value Type='Text'>CustomLearningViewer.aspx</Value></Eq></Where></Query></View>"


### PR DESCRIPTION
Fixes #1013

`Get-PnPList -Identity "Site Pages"` resolves the list by its localized Title, which SharePoint Online renames according to the site's default language (e.g. "Páginas del sitio" on es-ES sites). This makes the script fail with `Could not find "Site Pages" library` on any non-English site, even though the library exists.

This resolves the list by its stable `EntityTypeName` (`SitePages`) instead, which doesn't change across languages.

Tested against a Spanish (es-ES, LCID 3082) communication site where the original script failed and the fixed script succeeds.